### PR TITLE
Add support for Oauth2 Bearer token

### DIFF
--- a/lib/emma.js
+++ b/lib/emma.js
@@ -46,7 +46,7 @@ module.exports = function (parameters) {
       };
     else if (this.settings.accessToken)
       requestOptions.auth = {
-        bearer: this.settings.bearer = this.settings.accessToken,
+        bearer: this.settings.accessToken,
         sendImmediately: true
       };
     else

--- a/lib/emma.js
+++ b/lib/emma.js
@@ -14,7 +14,8 @@ module.exports = function (parameters) {
     baseURL: "https://api.e2ma.net" || parameters.baseURL,
     publicKey: null || parameters.publicKey,
     privateKey: null || parameters.privateKey,
-    accountID: null || parameters.accountID
+    accountID: null || parameters.accountID,
+    accessToken: null || parameters.accessToken
   };
 
   /* Attach internal method for sending a request off to the Emma API.
@@ -41,10 +42,15 @@ module.exports = function (parameters) {
       requestOptions.auth = {
         username: this.settings.publicKey,
         password: this.settings.privateKey,
-        sendImmeadiately: true
+        sendImmediately: true
+      };
+    else if (this.settings.accessToken)
+      requestOptions.auth = {
+        bearer: this.settings.bearer = this.settings.accessToken,
+        sendImmediately: true
       };
     else
-      throw new Error('Must specify valid public and private key for Emma API when creating the client.');
+      throw new Error('Must specify valid public and private key or access token for Emma API when creating the client.');
 
     // If the verb is PUT or POST check for a body and attach it.
     if (requestDetails.verb == 'POST' | requestDetails.verb == 'PUT')


### PR DESCRIPTION
Emma has an Oauth2 implementation they don't have advertised but is available to some people which may be connected using other Oauth libraries to obtain an access token which can then be used with this SDK by passing a bearer token which the requests library already supports. 

We're using this small change which is working well for us.
