### PR TITLE
Memer optOut withEmail method fails due to unset variable query.

### DIFF
--- a/lib/categories/member.js
+++ b/lib/categories/member.js
@@ -136,6 +136,7 @@ module.exports = function (client) {
 
         // http://api.myemma.com/api/external/members.html#put--#account_id-members-email-optout--email
         optOut: function (callback) {
+          var query = {};
           client.request({verb: 'PUT', url: 'members/email/optout/' + email}, {query: query}, callback);
         }
       };


### PR DESCRIPTION
The variable query is set in the details method directly above but not in the optOut method. This addresses the issue by setting the query variable to an empty object just like in the details method.